### PR TITLE
Fix deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ dependencies = [
     "matplotlib",
     "multiprocess",
     "numpy<2.0.0",
+    "pandas>=2.0.0",
     "planetary-computer @ git+https://github.com/fkroeber/planetary-computer-sdk-for-python.git",
     "rioxarray<=0.15.5",
     "semantique @ git+https://github.com/fkroeber/semantique.git@latest",

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,12 @@ dependencies = [
     "ipykernel",
     "matplotlib",
     "multiprocess",
-    "pandas>=2.0.0",
+    "numpy<2.0.0",
     "planetary-computer @ git+https://github.com/fkroeber/planetary-computer-sdk-for-python.git",
     "rioxarray<=0.15.5",
     "semantique @ git+https://github.com/fkroeber/semantique.git@latest",
     "stac-asset==0.4.0",
-    "stackstac @ git+https://github.com/fkroeber/stackstac.git",
+    "stackstac @ git+https://github.com/fkroeber/stackstac.git@fix_v1",
     "tqdm",
 ]
 


### PR DESCRIPTION
#### Description

Pinning the versions of numpy and stackstac. The stackstac version remains the same as before (renamed branch to fix_v1). In theory, the reasons to use this altered branch (pd.datetime conversion and shape error) have been mitigated by the most recent [stackstac version 0.5.1](https://github.com/gjoseph92/stackstac/blob/main/CHANGELOG.md#051-2024-08-09). However, new complications introduced with numpy>2 version concerning [dtype conversions](https://github.com/gjoseph92/stackstac/issues/260) prevent a shift to the original stackstac repo and its current head. Until, this is fixed, we pin numpy<2. 

Note: As soon as the problem on numpy dtypes is fixed within stackstac, we may omit the forked stackstac reference and switch to the original repository. Pandas and numpy pinning could be removed then, since stackstac>0.5.1 requires pandas>2 anyway.

#### Type of change

Select one or more relevant options:

- [ ] Bug fix (change which fixes a bug reported in a specific issue)
- [ ] New feature (change which adds a feature requested in a specific issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improved documentation for existing functionality in the package)
- [ ] Repository update (change related to non-package files or structures in the GitHub repository)

#### Checklist:

- [x] I have read and understood the [contributor guidelines](../CONTRIBUTING.md) of this project
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I ran all [demo notebooks](../demo) locally and there where no errors
